### PR TITLE
Fix mount issue for peer, fix path typo in prepare-files.sh

### DIFF
--- a/fabric-1.0/driving-files/prepare-files.sh
+++ b/fabric-1.0/driving-files/prepare-files.sh
@@ -8,9 +8,9 @@
 
 rm -rf  orderer/*
 rm -rf fabric-peer/peer0-org1/*
-rm -rf  fabric-peer/peer1-org1/*
-rm -rf  fabric-peer/peer1-org1/*
 rm -rf fabric-peer/peer1-org1/*
+rm -rf fabric-peer/peer0-org2/*
+rm -rf fabric-peer/peer1-org2/*
 
 cp -r ./channel-artifacts/genesis.block ./orderer/orderer.genesis.block
 cp -r ./crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/* ./orderer/

--- a/fabric-1.0/local/cli.yaml
+++ b/fabric-1.0/local/cli.yaml
@@ -16,8 +16,8 @@ spec:
       restartPolicy: Always
       containers:
         - name: cli-container
-          imagePullPolicy: Never
-          image: hyperledger/fabric-tools:latest
+          imagePullPolicy: IfNotPresent
+          image: hyperledger/fabric-peer:latest
           workingDir: /opt/gopath/src/github.com/hyperledger/fabric/peer
           tty: true
           volumeMounts:

--- a/fabric-1.0/local/cli.yaml
+++ b/fabric-1.0/local/cli.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: cli-container
           imagePullPolicy: IfNotPresent
-          image: hyperledger/fabric-peer:latest
+          image: hyperledger/fabric-tools:latest #The image is changed to fabric-tools in latest version of e2e_cli samples
           workingDir: /opt/gopath/src/github.com/hyperledger/fabric/peer
           tty: true
           volumeMounts:
@@ -41,7 +41,7 @@ spec:
             - name: CORE_PEER_LOCALMSPID
               value: "Org1MSP"
             - name: CORE_PEER_TLS_ENABLED
-              value: "true"
+              value: "false"
             - name: CORE_PEER_TLS_CERT_FILE
               value: "/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/server.crt"
             - name: CORE_PEER_TLS_KEY_FILE

--- a/fabric-1.0/local/orderer.yaml
+++ b/fabric-1.0/local/orderer.yaml
@@ -45,7 +45,7 @@ spec:
             - name: ORDERER_GENERAL_LISTENPORT
               value: "7050"
             - name: ORDERER_GENERAL_TLS_ENABLED
-              value: "true"
+              value: "false"
             - name: ORDERER_RAMLEDGER_HISTORY_SIZE
               value: "100"
             - name: CONFIGTX_ORDERER_ORDERERTYPE

--- a/fabric-1.0/local/peer0.yaml
+++ b/fabric-1.0/local/peer0.yaml
@@ -21,25 +21,30 @@ spec:
       restartPolicy: Always
       containers:
         - name: peer0-org1-container
-          imagePullPolicy: Never
+          imagePullPolicy: IfNotPresent
           image: hyperledger/fabric-peer:latest
+          workingDir: /opt/gopath/src/github.com/hyperledger/fabric/peer
           volumeMounts:
-            - mountPath: /etc/hyperledger/fabric
-              name: fabric-vol
+            - mountPath: /etc/hyperledger/fabric/msp
+              name: fabric-vol-msp
+            - mountPath: /etc/hyperledger/fabric/tls
+              name: fabric-vol-tls
           env:
+            - name: CORE_VM_ENDPOINT
+              value: unix:///host/var/run/docker.sock
             - name: CORE_PEER_ID
               value: "peer0-org1"
             - name: CORE_PEER_ADDRESS
               value: "peer0-org1:7051"
-            - name: CORE_PEER_CHAINCODELISTENADDRESS
-              value: "peer0-org1:7052"
+            #- name: CORE_PEER_CHAINCODELISTENADDRESS
+            #  value: "peer0-org1:7052"
             - name: CORE_PEER_GOSSIP_EXTERNALENDPOINT
+              value: "peer0-org1:7051"
+            - name: CORE_PEER_GOSSIP_BOOTSTRAP
               value: "peer0-org1:7051"
             - name: CORE_PEER_LOCALMSPID
               value: "Org1MSP"
             - name: CORE_PEER_GOSSIP_ORGLEADER
-              value: "true"
-            - name: CORE_PEER_ADDRESSAUTODETECT
               value: "false"
             - name: CORE_LOGGING_LEVEL
               value: "DEBUG"
@@ -49,8 +54,10 @@ spec:
               value: "true"
             - name: CORE_PEER_GOSSIP_ORGLEADER
               value: "false"
+            - name: CORE_PEER_GOSSIP_SKIPHANDSHAKE
+              value: "true"
             - name: CORE_PEER_PROFILE_ENABLED
-              value: "false"
+              value: "true"
             - name: CORE_PEER_TLS_ENABLED
               value: "false"
             - name: CORE_PEER_TLS_CERT_FILE
@@ -58,11 +65,11 @@ spec:
             - name: CORE_PEER_TLS_KEY_FILE
               value: "/etc/hyperledger/fabric/tls/server.key"
             - name: CORE_PEER_TLS_ROOTCERT_FILE
-              value: /etc/hyperledger/fabric/tls/ca.crt
+              value: "/etc/hyperledger/fabric/tls/ca.crt"
           ports:
-            - containerPort: 7050
+            #- containerPort: 7050
             - containerPort: 7051
-            - containerPort: 7052
+            #- containerPort: 7052
             - containerPort: 7053
             # - containerPort: 7054
             # - containerPort: 7055
@@ -71,17 +78,24 @@ spec:
             # - containerPort: 7058
             # - containerPort: 7059
           command:
-            # - /bin/bash
+            #- /bin/bash
+            #- sh
+            #- -c
+            #- "sleep 10; peer node start"
             - peer
             - node
             - start
-          # command:
-          #   - cat
-          #   - "/etc/hyperledger/fabric/tls/server.crt"
+            - --peer-defaultchain=false
+          #command:
+            #- cat
+            #- "/etc/hyperledger/fabric/tls/server.crt"
       volumes:
-        - name: fabric-vol
+        - name: fabric-vol-msp
           hostPath:
-            path: /data/driving-files/fabric-peer/peer0-org1
+            path: /data/driving-files/fabric-peer/peer0-org1/msp
+        - name: fabric-vol-tls
+          hostPath:
+            path: /data/driving-files/fabric-peer/peer0-org1/tls
 ---
 apiVersion: v1
 kind: Service
@@ -92,15 +106,15 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - name: "7050"
-      targetPort: 7050
-      port: 7050
+    #- name: "7050"
+    #  targetPort: 7050
+    #  port: 7050
     - name: "7051"
       targetPort: 7051
       port: 7051
-    - name: "7052"
-      targetPort: 7052
-      port: 7052
+    #- name: "7052"
+    #  targetPort: 7052
+    #  port: 7052
     - name: "7053"
       targetPort: 7053
       port: 7053

--- a/fabric-1.0/local/peer1.yaml
+++ b/fabric-1.0/local/peer1.yaml
@@ -21,27 +21,30 @@ spec:
       restartPolicy: Always
       containers:
         - name: peer1-org1-container
-          imagePullPolicy: Never
+          imagePullPolicy: IfNotPresent
           image: hyperledger/fabric-peer:latest
+          workingDir: /opt/gopath/src/github.com/hyperledger/fabric/peer
           volumeMounts:
-            - mountPath: /etc/hyperledger/fabric
-              name: fabric-vol
+            - mountPath: /etc/hyperledger/fabric/msp
+              name: fabric-vol-msp
+            - mountPath: /etc/hyperledger/fabric/tls
+              name: fabric-vol-tls
           env:
-            - name: CORE_PEER_GOSSIP_BOOTSTRAP
-              value: "peer0-org1:7051"
+            - name: CORE_VM_ENDPOINT
+              value: unix:///host/var/run/docker.sock
             - name: CORE_PEER_ID
               value: "peer1-org1"
             - name: CORE_PEER_ADDRESS
               value: "peer1-org1:7051"
-            - name: CORE_PEER_CHAINCODELISTENADDRESS
-              value: "peer1-org1:7052"
+            #- name: CORE_PEER_CHAINCODELISTENADDRESS
+            #  value: "peer1-org1:7052"
             - name: CORE_PEER_GOSSIP_EXTERNALENDPOINT
               value: "peer1-org1:7051"
+            - name: CORE_PEER_GOSSIP_BOOTSTRAP
+              value: "peer0-org1:7051"
             - name: CORE_PEER_LOCALMSPID
               value: "Org1MSP"
             - name: CORE_PEER_GOSSIP_ORGLEADER
-              value: "true"
-            - name: CORE_PEER_ADDRESSAUTODETECT
               value: "false"
             - name: CORE_LOGGING_LEVEL
               value: "DEBUG"
@@ -51,8 +54,10 @@ spec:
               value: "true"
             - name: CORE_PEER_GOSSIP_ORGLEADER
               value: "false"
+            - name: CORE_PEER_GOSSIP_SKIPHANDSHAKE
+              value: "true"
             - name: CORE_PEER_PROFILE_ENABLED
-              value: "false"
+              value: "true"
             - name: CORE_PEER_TLS_ENABLED
               value: "false"
             - name: CORE_PEER_TLS_CERT_FILE
@@ -60,11 +65,11 @@ spec:
             - name: CORE_PEER_TLS_KEY_FILE
               value: "/etc/hyperledger/fabric/tls/server.key"
             - name: CORE_PEER_TLS_ROOTCERT_FILE
-              value: /etc/hyperledger/fabric/tls/ca.crt
+              value: "/etc/hyperledger/fabric/tls/ca.crt"
           ports:
-            - containerPort: 7050
+            #- containerPort: 7050
             - containerPort: 7051
-            - containerPort: 7052
+            #- containerPort: 7052
             - containerPort: 7053
             # - containerPort: 7054
             # - containerPort: 7055
@@ -73,13 +78,24 @@ spec:
             # - containerPort: 7058
             # - containerPort: 7059
           command:
+            #- /bin/bash
+            #- sh
+            #- -c
+            #- "sleep 10; peer node start"
             - peer
             - node
             - start
+            - --peer-defaultchain=false
+          #command:
+            #- cat
+            #- "/etc/hyperledger/fabric/tls/server.crt"
       volumes:
-        - name: fabric-vol
+        - name: fabric-vol-msp
           hostPath:
-            path: /data/driving-files/fabric-peer/peer1-org1
+            path: /data/driving-files/fabric-peer/peer1-org1/msp
+        - name: fabric-vol-tls
+          hostPath:
+            path: /data/driving-files/fabric-peer/peer1-org1/tls
 ---
 apiVersion: v1
 kind: Service
@@ -90,15 +106,15 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - name: "7050"
-      targetPort: 7050
-      port: 7050
+    #- name: "7050"
+    #  targetPort: 7050
+    #  port: 7050
     - name: "7051"
       targetPort: 7051
       port: 7051
-    - name: "7052"
-      targetPort: 7052
-      port: 7052
+    #- name: "7052"
+    #  targetPort: 7052
+    #  port: 7052
     - name: "7053"
       targetPort: 7053
       port: 7053

--- a/fabric-1.0/local/peer2.yaml
+++ b/fabric-1.0/local/peer2.yaml
@@ -21,27 +21,30 @@ spec:
       restartPolicy: Always
       containers:
         - name: peer0-org2-container
-          imagePullPolicy: Never
+          imagePullPolicy: IfNotPresent
           image: hyperledger/fabric-peer:latest
+          workingDir: /opt/gopath/src/github.com/hyperledger/fabric/peer
           volumeMounts:
-            - mountPath: /etc/hyperledger/fabric
-              name: fabric-vol
+            - mountPath: /etc/hyperledger/fabric/msp
+              name: fabric-vol-msp
+            - mountPath: /etc/hyperledger/fabric/tls
+              name: fabric-vol-tls
           env:
-            - name: CORE_PEER_GOSSIP_BOOTSTRAP
-              value: "peer0-org2:7051"
+            - name: CORE_VM_ENDPOINT
+              value: unix:///host/var/run/docker.sock
             - name: CORE_PEER_ID
               value: "peer0-org2"
             - name: CORE_PEER_ADDRESS
               value: "peer0-org2:7051"
-            - name: CORE_PEER_CHAINCODELISTENADDRESS
-              value: "peer0-org2:7052"
+            #- name: CORE_PEER_CHAINCODELISTENADDRESS
+            #  value: "peer0-org2:7052"
             - name: CORE_PEER_GOSSIP_EXTERNALENDPOINT
-              value: "peer1-org1:7051"
+              value: "peer0-org2:7051"
+            - name: CORE_PEER_GOSSIP_BOOTSTRAP
+              value: "peer0-org2:7051"
             - name: CORE_PEER_LOCALMSPID
-              value: "Org2MSP"
+              value: "org2MSP"
             - name: CORE_PEER_GOSSIP_ORGLEADER
-              value: "true"
-            - name: CORE_PEER_ADDRESSAUTODETECT
               value: "false"
             - name: CORE_LOGGING_LEVEL
               value: "DEBUG"
@@ -51,8 +54,10 @@ spec:
               value: "true"
             - name: CORE_PEER_GOSSIP_ORGLEADER
               value: "false"
+            - name: CORE_PEER_GOSSIP_SKIPHANDSHAKE
+              value: "true"
             - name: CORE_PEER_PROFILE_ENABLED
-              value: "false"
+              value: "true"
             - name: CORE_PEER_TLS_ENABLED
               value: "false"
             - name: CORE_PEER_TLS_CERT_FILE
@@ -62,9 +67,9 @@ spec:
             - name: CORE_PEER_TLS_ROOTCERT_FILE
               value: "/etc/hyperledger/fabric/tls/ca.crt"
           ports:
-            - containerPort: 7050
+            #- containerPort: 7050
             - containerPort: 7051
-            - containerPort: 7052
+            #- containerPort: 7052
             - containerPort: 7053
             # - containerPort: 7054
             # - containerPort: 7055
@@ -73,13 +78,24 @@ spec:
             # - containerPort: 7058
             # - containerPort: 7059
           command:
+            #- /bin/bash
+            #- sh
+            #- -c
+            #- "sleep 10; peer node start"
             - peer
             - node
             - start
+            - --peer-defaultchain=false
+          #command:
+            #- cat
+            #- "/etc/hyperledger/fabric/tls/server.crt"
       volumes:
-        - name: fabric-vol
+        - name: fabric-vol-msp
           hostPath:
-            path: /data/driving-files/fabric-peer/peer0-org2
+            path: /data/driving-files/fabric-peer/peer0-org2/msp
+        - name: fabric-vol-tls
+          hostPath:
+            path: /data/driving-files/fabric-peer/peer0-org2/tls
 ---
 apiVersion: v1
 kind: Service
@@ -90,15 +106,15 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - name: "7050"
-      targetPort: 7050
-      port: 7050
+    #- name: "7050"
+    #  targetPort: 7050
+    #  port: 7050
     - name: "7051"
       targetPort: 7051
       port: 7051
-    - name: "7052"
-      targetPort: 7052
-      port: 7052
+    #- name: "7052"
+    #  targetPort: 7052
+    #  port: 7052
     - name: "7053"
       targetPort: 7053
       port: 7053

--- a/fabric-1.0/local/peer3.yaml
+++ b/fabric-1.0/local/peer3.yaml
@@ -11,7 +11,7 @@ spec:
   replicas: 1
   template:
     metadata:
-      name: peer-pod3
+      name: peer-pod2
       labels:
         app: hyperledger
         role: peer
@@ -21,27 +21,30 @@ spec:
       restartPolicy: Always
       containers:
         - name: peer1-org2-container
-          imagePullPolicy: Never
+          imagePullPolicy: IfNotPresent
           image: hyperledger/fabric-peer:latest
+          workingDir: /opt/gopath/src/github.com/hyperledger/fabric/peer
           volumeMounts:
-            - mountPath: /etc/hyperledger/fabric
-              name: fabric-vol
+            - mountPath: /etc/hyperledger/fabric/msp
+              name: fabric-vol-msp
+            - mountPath: /etc/hyperledger/fabric/tls
+              name: fabric-vol-tls
           env:
-            - name: CORE_PEER_GOSSIP_BOOTSTRAP
-              value: "peer1-org2:7051"
+            - name: CORE_VM_ENDPOINT
+              value: unix:///host/var/run/docker.sock
             - name: CORE_PEER_ID
               value: "peer1-org2"
             - name: CORE_PEER_ADDRESS
               value: "peer1-org2:7051"
-            - name: CORE_PEER_CHAINCODELISTENADDRESS
-              value: "peer1-org2:7052"
+            #- name: CORE_PEER_CHAINCODELISTENADDRESS
+            #  value: "peer1-org2:7052"
             - name: CORE_PEER_GOSSIP_EXTERNALENDPOINT
               value: "peer1-org2:7051"
+            - name: CORE_PEER_GOSSIP_BOOTSTRAP
+              value: "peer0-org2:7051"
             - name: CORE_PEER_LOCALMSPID
-              value: "Org2MSP"
+              value: "org2MSP"
             - name: CORE_PEER_GOSSIP_ORGLEADER
-              value: "true"
-            - name: CORE_PEER_ADDRESSAUTODETECT
               value: "false"
             - name: CORE_LOGGING_LEVEL
               value: "DEBUG"
@@ -51,8 +54,10 @@ spec:
               value: "true"
             - name: CORE_PEER_GOSSIP_ORGLEADER
               value: "false"
+            - name: CORE_PEER_GOSSIP_SKIPHANDSHAKE
+              value: "true"
             - name: CORE_PEER_PROFILE_ENABLED
-              value: "false"
+              value: "true"
             - name: CORE_PEER_TLS_ENABLED
               value: "false"
             - name: CORE_PEER_TLS_CERT_FILE
@@ -62,9 +67,9 @@ spec:
             - name: CORE_PEER_TLS_ROOTCERT_FILE
               value: "/etc/hyperledger/fabric/tls/ca.crt"
           ports:
-            - containerPort: 7050
+            #- containerPort: 7050
             - containerPort: 7051
-            - containerPort: 7052
+            #- containerPort: 7052
             - containerPort: 7053
             # - containerPort: 7054
             # - containerPort: 7055
@@ -73,13 +78,24 @@ spec:
             # - containerPort: 7058
             # - containerPort: 7059
           command:
+            #- /bin/bash
+            #- sh
+            #- -c
+            #- "sleep 10; peer node start"
             - peer
             - node
             - start
+            - --peer-defaultchain=false
+          #command:
+            #- cat
+            #- "/etc/hyperledger/fabric/tls/server.crt"
       volumes:
-        - name: fabric-vol
+        - name: fabric-vol-msp
           hostPath:
-            path: /data/driving-files/fabric-peer/peer1-org2
+            path: /data/driving-files/fabric-peer/peer1-org2/msp
+        - name: fabric-vol-tls
+          hostPath:
+            path: /data/driving-files/fabric-peer/peer1-org2/tls
 ---
 apiVersion: v1
 kind: Service
@@ -90,15 +106,15 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - name: "7050"
-      targetPort: 7050
-      port: 7050
+    #- name: "7050"
+    #  targetPort: 7050
+    #  port: 7050
     - name: "7051"
       targetPort: 7051
       port: 7051
-    - name: "7052"
-      targetPort: 7052
-      port: 7052
+    #- name: "7052"
+    #  targetPort: 7052
+    #  port: 7052
     - name: "7053"
       targetPort: 7053
       port: 7053


### PR DESCRIPTION
In the peer, we can't mount like this:
    volumeMounts:
            - mountPath: /etc/hyperledger/fabric/

If we do this, the core.yaml file which is default in peer image will be overwritten and gone. So the peer will meet an error when starts like:
    Error reading CORE_PBFT plugin config: Unsupported Config Type ""